### PR TITLE
fix(linked_hashmap): wrong iterator traits

### DIFF
--- a/linked_hashmap/linked_hashmap.hpp
+++ b/linked_hashmap/linked_hashmap.hpp
@@ -61,9 +61,9 @@ public:
 		// About value_type: https://blog.csdn.net/u014299153/article/details/72419713
 		// About iterator_category: https://en.cppreference.com/w/cpp/iterator
 		using difference_type = std::ptrdiff_t;
-		using value_type = std::pair<Key,T>;
-		using pointer = T*;
-		using reference = T&;
+		using value_type = typename linked_hashmap::value_type;
+		using pointer = value_type*;
+		using reference = value_type&;
 		using iterator_category = std::output_iterator_tag;
 
 


### PR DESCRIPTION
Changes linked_hashmap::iterator::value_type from pair<Key, T> to pair<const Key, T>, pointer from T* to value_type*, and reference from T& to value_type&. The original typedefs made no sense.

Credit goes to @RabbitCabbage for pointing out.
See also: #3