### PR TITLE
fix(linked_hashmap): testpoint reports failure when it actually succeded

### DIFF
--- a/linked_hashmap/data/testthree/5.ans
+++ b/linked_hashmap/data/testthree/5.ans
@@ -39355,7 +39355,7 @@ Test 2 Passed!
 1962130 543589
 Test 3 Passed!
 543589 543589
-Test 4 Failed......
+Test 4 Passed!
 543589 543589
 1000
 1001 1001

--- a/linked_hashmap/data/testthree/5.cpp
+++ b/linked_hashmap/data/testthree/5.cpp
@@ -108,8 +108,8 @@ bool check4(){//const_iterator
 		cout<< it -> first<<" "<<(*it).second<<'\n';
 	}
 	itt = --Q.cend();
-	if(it == itt) return 0;
-	return 1;
+	if(it == itt) return 1;
+	return 0;
 }
 
 bool check5(){// insert && remove 

--- a/linked_hashmap/data/testthree_memcheck/6.ans
+++ b/linked_hashmap/data/testthree_memcheck/6.ans
@@ -39355,7 +39355,7 @@ Test 2 Passed!
 1962130 543589
 Test 3 Passed!
 543589 543589
-Test 4 Failed......
+Test 4 Passed!
 543589 543589
 1000
 1001 1001

--- a/linked_hashmap/data/testthree_memcheck/6.cpp
+++ b/linked_hashmap/data/testthree_memcheck/6.cpp
@@ -108,8 +108,8 @@ bool check4(){//const_iterator
 		cout<< it -> first<<" "<<(*it).second<<'\n';
 	}
 	itt = --Q.cend();
-	if(it == itt) return 0;
-	return 1;
+	if(it == itt) return 1;
+	return 0;
 }
 
 bool check5(){// insert && remove 


### PR DESCRIPTION
In test 3 and its corresponding memcheck testpoint, subtask 4 reports itself as failed when it actually succeded, and succeded when it actually failed. This also affects the corresponding answer files. This commit fixes it.

Credit goes to @LauYeeYu for pointing out.